### PR TITLE
Remove hidden cells

### DIFF
--- a/jupyter_book_to_htmlbook/chapter_processing.py
+++ b/jupyter_book_to_htmlbook/chapter_processing.py
@@ -93,9 +93,21 @@ def clean_chapter(chapter, rm_numbering=True):
         for span in chapter.find_all(class_="section-number"):
             span.decompose()
 
-    # remove any heading links
-    for link in chapter.find_all(class_="headerlink"):
-        link.decompose()
+    tags_to_remove = [
+        # remove hidden cells. in the web version, these cells are hidden by
+        # default and users can toggle them on/off. but they take up too much
+        # space if rendered into the pdf.
+        ".tag_hide-input > .cell_input",
+        ".tag_hide-output > .cell_output",
+        ".tag_hide-cell",
+        ".toggle-details",
+
+        # remove any heading links
+        ".headerlink",
+    ]
+
+    for el in chapter.select(','.join(tags_to_remove)):
+        el.decompose()
     return chapter
 
 


### PR DESCRIPTION
In the Web book, we have hidden cells that the user can toggle on (e.g.
http://www.textbook.ds100.org/ch/11/viz_scale.html). But in the PDF,
hidden cells are shown. This PR removes these cells from the PDF output
since they weren't designed to be read by a first-time reader.